### PR TITLE
feat(auth): require service tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,7 @@ LOGS_FILE="object_effects"
 URBAN_API="https://urban-api.testing"
 MCP_URBAN_API="https://urban-api.testing"
 PROMETHEUS_PORT=9464
+SERVICE_AUTH_SERVER_URL=https://keycloak.example.com
+SERVICE_AUTH_REALM=IDU
+SERVICE_AUTH_CLIENT_ID=object-effects
+SERVICE_AUTH_CLIENT_SECRET=change-me

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -48,5 +48,10 @@ jobs:
           ENV_PATH: ${{secrets.ENV_PATH}}
         run: cp "$ENV_PATH"/.env.development ./
       - name: run
+        env:
+          SERVICE_AUTH_SERVER_URL: ${{ vars.SERVICE_AUTH_SERVER_URL }}
+          SERVICE_AUTH_REALM: ${{ vars.SERVICE_AUTH_REALM }}
+          SERVICE_AUTH_CLIENT_ID: ${{ vars.SERVICE_AUTH_CLIENT_ID }}
+          SERVICE_AUTH_CLIENT_SECRET: ${{ secrets.SERVICE_AUTH_CLIENT_SECRET }}
 #        run: docker run -d --name "$CONTAINER_NAME" --env-file ./.env.development -p 8210:8000 "$IMAGE_NAME":"$NOW"
         run: docker compose -f docker-compose.actions.yml up -d

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ ENV APP_ENV=development
 COPY pip.conf /etc/xdg/pip/pip.conf
 # Install pip requirements
 COPY requirements.txt .
-RUN python -m pip install -r requirements.txt
+COPY requirements-auth.txt .
+RUN python -m pip install -r requirements.txt -r requirements-auth.txt
 
 WORKDIR /app
 COPY . /app

--- a/app/common/api_handler/api_handler.py
+++ b/app/common/api_handler/api_handler.py
@@ -1,4 +1,5 @@
 import aiohttp
+from idu_service_auth import KeycloakTokenClient
 
 from app.common.exceptions.http_exception_wrapper import http_exception
 
@@ -8,6 +9,7 @@ class APIHandler:
     def __init__(
         self,
         base_url: str,
+        service_auth: KeycloakTokenClient,
     ) -> None:
         """Initialisation function
 
@@ -18,6 +20,12 @@ class APIHandler:
         """
 
         self.base_url = base_url
+        self.service_auth = service_auth
+
+    async def _service_headers(self, headers: dict | None) -> dict[str, str]:
+        outgoing = dict(headers or {})
+        outgoing.update(await self.service_auth.get_authorization_headers())
+        return outgoing
 
     @staticmethod
     async def _check_response_status(
@@ -89,6 +97,7 @@ class APIHandler:
                     params=params,
                     session=session,
                 )
+        headers = await self._service_headers(headers)
         url = self.base_url + endpoint_url
         async with session.get(url=url, headers=headers, params=params) as response:
             result = await self._check_response_status(response)
@@ -138,6 +147,7 @@ class APIHandler:
                     data=data,
                     session=session,
                 )
+        headers = await self._service_headers(headers)
         url = self.base_url + endpoint_url
         async with session.post(
             url=url,
@@ -184,6 +194,7 @@ class APIHandler:
                     data=data,
                     session=session,
                 )
+        headers = await self._service_headers(headers)
         url = self.base_url + endpoint_url
         async with session.put(
             url=url,
@@ -230,6 +241,7 @@ class APIHandler:
                     data=data,
                     session=session,
                 )
+        headers = await self._service_headers(headers)
         url = self.base_url + endpoint_url
         async with session.delete(
             url=url,

--- a/app/common/auth/service_auth.py
+++ b/app/common/auth/service_auth.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from fastapi import Header, HTTPException, Security, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastmcp.exceptions import AuthorizationError, ToolError
+from fastmcp.server.auth import AccessToken
+from fastmcp.server.auth.providers.jwt import JWTVerifier
+from fastmcp.server.dependencies import get_http_headers
+from idu_service_auth import KeycloakTokenClient, KeycloakTokenConfig
+
+from app.common.config.config import Config
+
+USER_ID_HEADER = "X-User-Id"
+SERVICE_ACCOUNT_PREFIX = "service-account-"
+bearer_scheme = HTTPBearer(auto_error=True)
+
+
+def build_service_auth(config: Config) -> KeycloakTokenClient:
+    return KeycloakTokenClient(
+        KeycloakTokenConfig(
+            auth_server_url=config.get("SERVICE_AUTH_SERVER_URL"),
+            realm=config.get("SERVICE_AUTH_REALM"),
+            client_id=config.get("SERVICE_AUTH_CLIENT_ID"),
+            client_secret=config.get("SERVICE_AUTH_CLIENT_SECRET"),
+            background_refresh=True,
+        )
+    )
+
+
+def build_service_token_verifier(config: Config) -> "ServiceTokenVerifier":
+    return ServiceTokenVerifier(config)
+
+
+async def get_current_user_id(
+    _credentials: HTTPAuthorizationCredentials = Security(bearer_scheme),
+    x_user_id: str | None = Header(default=None, alias=USER_ID_HEADER),
+) -> str:
+    if not x_user_id or not x_user_id.strip():
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"{USER_ID_HEADER} header is required",
+        )
+    return x_user_id.strip()
+
+
+async def require_service_token(
+    credentials: HTTPAuthorizationCredentials = Security(bearer_scheme),
+) -> None:
+    """Require a verified Keycloak service-account token."""
+
+    from app.dependencies import service_token_verifier
+
+    try:
+        access_token = await service_token_verifier.verify_token(
+            credentials.credentials
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid service token",
+        ) from exc
+    if access_token is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid service token",
+        )
+
+
+def get_mcp_user_id() -> str:
+    user_id = get_http_headers(include_all=True).get("x-user-id", "").strip()
+    if not user_id:
+        raise ToolError(f"{USER_ID_HEADER} header is required")
+    return user_id
+
+
+class ServiceTokenVerifier(JWTVerifier):
+    """Verify Keycloak JWTs and accept only client-credentials accounts."""
+
+    def __init__(self, config: Config) -> None:
+        server_url = config.get("SERVICE_AUTH_SERVER_URL").rstrip("/")
+        realm = config.get("SERVICE_AUTH_REALM")
+        issuer = f"{server_url}/realms/{realm}"
+        super().__init__(
+            jwks_uri=f"{issuer}/protocol/openid-connect/certs",
+            issuer=issuer,
+            algorithm="RS256",
+        )
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        access_token = await super().verify_token(token)
+        if access_token is None:
+            return None
+        username = access_token.claims.get("preferred_username", "")
+        if not isinstance(username, str) or not username.startswith(
+            SERVICE_ACCOUNT_PREFIX
+        ):
+            raise AuthorizationError("A service-account token is required")
+        return access_token

--- a/app/common/modules/effects_api_gateway.py
+++ b/app/common/modules/effects_api_gateway.py
@@ -5,6 +5,7 @@ import pandas as pd
 from shapely.geometry import shape
 
 from app.common.api_handler.api_handler import APIHandler
+from app.common.auth.service_auth import USER_ID_HEADER
 from app.common.exceptions.http_exception_wrapper import http_exception
 
 
@@ -27,7 +28,7 @@ class EffectsAPIGateway:
 
         proj_resp = await self.api_handler.get(
             f"/api/v1/scenarios/{scenario_id}",
-            headers={"Authorization": f"Bearer {token}"} if token else None,
+            headers={USER_ID_HEADER: token} if token else None,
         )
         return proj_resp["project"]["project_id"]
 
@@ -54,13 +55,13 @@ class EffectsAPIGateway:
         if len(context_ids) == 1:
             response = await self.api_handler.get(
                 f"/api/v1/territory/{context_ids[0]}/normatives",
-                headers={"Authorization": f"Bearer {token}"} if token else None,
+                headers={USER_ID_HEADER: token} if token else None,
             )
             request_ter_id = context_ids[0]
         else:
             response = await self.api_handler.get(
                 f"/api/v1/territory/{territory_id}/normatives",
-                headers={"Authorization": f"Bearer {token}"} if token else None,
+                headers={USER_ID_HEADER: token} if token else None,
             )
             request_ter_id = territory_id
         response_df = pd.DataFrame.from_records(response)
@@ -153,7 +154,7 @@ class EffectsAPIGateway:
 
         response = await self.api_handler.get(
             endpoint_url=f"/api/v1/projects/{project_id}",
-            headers={"Authorization": f"Bearer {token}"} if token else None,
+            headers={USER_ID_HEADER: token} if token else None,
         )
 
         return response
@@ -173,7 +174,7 @@ class EffectsAPIGateway:
         buildings = await self.api_handler.get(
             endpoint_url=f"/api/v1/scenarios/{scenario_id}/geometries_with_all_objects",
             params={"physical_object_type_id": 4},
-            headers={"Authorization": f"Bearer {token}"} if token else None,
+            headers={USER_ID_HEADER: token} if token else None,
         )
         buildings_gdf = gpd.GeoDataFrame.from_features(buildings)
         if buildings_gdf.empty:
@@ -200,7 +201,7 @@ class EffectsAPIGateway:
             params={
                 "physical_object_type_id": 4,
             },
-            headers={"Authorization": f"Bearer {token}"} if token else None,
+            headers={USER_ID_HEADER: token} if token else None,
         )
         context_buildings_gdf = gpd.GeoDataFrame.from_features(context_buildings)
         if context_buildings_gdf.empty:
@@ -226,7 +227,7 @@ class EffectsAPIGateway:
             params={
                 "service_type_id": service_type_id,
             },
-            headers={"Authorization": f"Bearer {token}"} if token else None,
+            headers={USER_ID_HEADER: token} if token else None,
         )
         services_gdf = gpd.GeoDataFrame.from_features(services)
         if services_gdf.empty:
@@ -255,7 +256,7 @@ class EffectsAPIGateway:
             params={
                 "service_type_id": service_type_id,
             },
-            headers={"Authorization": f"Bearer {token}"} if token else None,
+            headers={USER_ID_HEADER: token} if token else None,
         )
         context_services_gdf = gpd.GeoDataFrame.from_features(context_services)
         if context_services_gdf.empty:
@@ -280,7 +281,7 @@ class EffectsAPIGateway:
             params={
                 "indicator_ids": 1,
             },
-            headers={"Authorization": f"Bearer {token}"} if token else None,
+            headers={USER_ID_HEADER: token} if token else None,
         )
 
         if len(population) < 1 or (value := population[0]["value"]) < 1:
@@ -303,7 +304,7 @@ class EffectsAPIGateway:
             self.api_handler.get(
                 endpoint_url=f"/api/v1/territory/{territory_id}/indicator_values",
                 params={"indicator_ids": 1},
-                headers={"Authorization": f"Bearer {token}"} if token else None,
+                headers={USER_ID_HEADER: token} if token else None,
             )
             for territory_id in territory_ids_list
         ]
@@ -325,7 +326,7 @@ class EffectsAPIGateway:
 
         territory = await self.api_handler.get(
             endpoint_url=f"/api/v1/projects/{project_id}/territory",
-            headers={"Authorization": f"Bearer {token}"} if token else None,
+            headers={USER_ID_HEADER: token} if token else None,
         )
         territory_gdf = gpd.GeoDataFrame(
             geometry=[shape(territory["geometry"])], crs=4326
@@ -366,7 +367,7 @@ class EffectsAPIGateway:
                 "service_type_id": service_type_id,
                 "include_scenario_objects": True,
             },
-            headers={"Authorization": f"Bearer {token}"} if token else None,
+            headers={USER_ID_HEADER: token} if token else None,
         )
         return gpd.GeoDataFrame.from_features(services, crs=4326)
 
@@ -389,6 +390,6 @@ class EffectsAPIGateway:
                 "physical_object_type_id": physical_object_type_id,
                 "include_scenario_objects": True,
             },
-            headers={"Authorization": f"Bearer {token}"} if token else None,
+            headers={USER_ID_HEADER: token} if token else None,
         )
         return gpd.GeoDataFrame.from_features(physical_objects, crs=4326)

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -3,6 +3,10 @@ import sys
 from loguru import logger
 
 from app.common.api_handler.api_handler import APIHandler
+from app.common.auth.service_auth import (
+    build_service_auth,
+    build_service_token_verifier,
+)
 from app.common.config.config import Config
 from app.common.exceptions.http_exception_wrapper import http_exception
 from app.common.modules.effects_api_gateway import EffectsAPIGateway
@@ -16,6 +20,8 @@ log_format = "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | <level>{level: <8}
 logger.add(sys.stderr, format=log_format, level=log_level, colorize=True)
 
 config = Config()
+service_auth = build_service_auth(config)
+service_token_verifier = build_service_token_verifier(config)
 
 logger.add(
     ".log",
@@ -23,8 +29,8 @@ logger.add(
     level="INFO",
 )
 
-urban_api_handler = APIHandler(config.get("URBAN_API"))
-urban_api_mcp_handler = APIHandler(config.get("MCP_URBAN_API"))
+urban_api_handler = APIHandler(config.get("URBAN_API"), service_auth)
+urban_api_mcp_handler = APIHandler(config.get("MCP_URBAN_API"), service_auth)
 
 effects_api_gateway = EffectsAPIGateway(urban_api_handler)
 effects_api_mcp_gateway = EffectsAPIGateway(urban_api_mcp_handler)

--- a/app/effects/effects_controller.py
+++ b/app/effects/effects_controller.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends
 
-from app.common.auth.bearer import verify_bearer_token
+from app.common.auth.service_auth import get_current_user_id
 from app.dependencies import effects_service
 from app.dto.provision_dto import ProvisionDTO
 
@@ -14,7 +14,7 @@ effects_router = APIRouter(prefix="/effects")
 @effects_router.get("/evaluate_provision", response_model=EffectsSchema)
 async def calculate_effects(
     params: Annotated[ProvisionDTO, Depends(ProvisionDTO)],
-    token: str = Depends(verify_bearer_token),
+    user_id: str = Depends(get_current_user_id),
 ) -> EffectsSchema:
 
-    return await effects_service.calculate_effects(params, token)
+    return await effects_service.calculate_effects(params, user_id)

--- a/app/effects/effects_mcp.py
+++ b/app/effects/effects_mcp.py
@@ -1,13 +1,13 @@
 import traceback
 
 from fastmcp import FastMCP
-from fastmcp.server.dependencies import get_access_token
 from loguru import logger
 
-from app.dependencies import effects_mcp_service
+from app.common.auth.service_auth import get_mcp_user_id
+from app.dependencies import effects_mcp_service, service_token_verifier
 from app.dto.provision_dto import ProvisionDTO
 
-effects_mcp = FastMCP("Object Effects MCP server")
+effects_mcp = FastMCP("Object Effects MCP server", auth=service_token_verifier)
 
 
 @effects_mcp.tool(
@@ -56,7 +56,7 @@ async def calc_provision_effects(
 ):
 
     try:
-        token = get_access_token()
+        token = get_mcp_user_id()
         project_id = await effects_mcp_service.gateway.get_project_id_by_scenario(
             scenario_id, token
         )

--- a/app/main.py
+++ b/app/main.py
@@ -1,15 +1,16 @@
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, RedirectResponse
 from fastmcp.utilities.lifespan import combine_lifespans
 from loguru import logger
 
 from .__version__ import APP_VERSION
+from .common.auth.service_auth import require_service_token
 from .common.middlewares.exception_handler import ExceptionHandlerMiddleware
 from .common.middlewares.prometheus_handler import ObservabilityMiddleware
-from .dependencies import config, http_exception
+from .dependencies import config, http_exception, service_auth
 from .effects.effects_controller import effects_router
 from .mcp import effects_mcp_app, provision_mcp_app
 from .observability import OpenTelemetryAgent, PrometheusConfig
@@ -37,7 +38,9 @@ async def lifespan(app: FastAPI):
     )
     setup_metrics()
     logger.info(f"Prometheus server started on {config.get('PROMETHEUS_PORT')}")
-    yield
+    async with service_auth:
+        await service_auth.get_access_token()
+        yield
     otel_agent.shutdown()
     logger.info("Prometheus server was shut down")
 
@@ -79,7 +82,7 @@ async def read_root():
     return {"status": "OK"}
 
 
-@app.get("/logs")
+@app.get("/logs", dependencies=[Depends(require_service_token)])
 async def get_logs():
     """
     Get logs file from app

--- a/app/provision/provision_controller.py
+++ b/app/provision/provision_controller.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends
 
-from app.common.auth.bearer import verify_bearer_token
+from app.common.auth.service_auth import get_current_user_id
 from app.dependencies import provision_service
 from app.dto.provision_dto import ProvisionDTO
 from app.schemas.provision_base_schema import (
@@ -17,18 +17,18 @@ provision_router = APIRouter(prefix="/provision", tags=["provision"])
 @provision_router.get("/calc_provision", response_model=ProvisionSchema)
 async def calculate_provision(
     provision_dto: Annotated[ProvisionDTO, Depends(ProvisionDTO)],
-    token: str = Depends(verify_bearer_token),
+    user_id: str = Depends(get_current_user_id),
 ) -> ProvisionSchema:
 
-    return await provision_service.calculate_provision(provision_dto, token)
+    return await provision_service.calculate_provision(provision_dto, user_id)
 
 
 @provision_router.post("/calc_provisions", response_model=MultiProvisionSchema)
 async def calculate_multi_provision(
     multi_provision_params: MultiProvisionRequestSchema,
-    token: str = Depends(verify_bearer_token),
+    user_id: str = Depends(get_current_user_id),
 ) -> MultiProvisionSchema:
 
     return await provision_service.calculate_multi_provision(
-        multi_provision_params, token
+        multi_provision_params, user_id
     )

--- a/app/provision/provision_mcp.py
+++ b/app/provision/provision_mcp.py
@@ -1,17 +1,17 @@
 import traceback
 
 from fastmcp import FastMCP
-from fastmcp.server.dependencies import get_access_token
 from loguru import logger
 
-from app.dependencies import provision_mcp_service
+from app.common.auth.service_auth import get_mcp_user_id
+from app.dependencies import provision_mcp_service, service_token_verifier
 from app.dto.provision_dto import ProvisionDTO
 from app.schemas.provision_base_schema import (
     MultiProvisionRequestSchema,
     ServiceInfoSchema,
 )
 
-provision_mcp = FastMCP("Object Provision MCP server")
+provision_mcp = FastMCP("Object Provision MCP server", auth=service_token_verifier)
 
 
 @provision_mcp.tool(
@@ -42,7 +42,7 @@ async def calc_service_provision(
 ):
 
     try:
-        token = get_access_token()
+        token = get_mcp_user_id()
         project_id = await provision_mcp_service.gateway.get_project_id_by_scenario(
             scenario_id, token
         )
@@ -115,7 +115,7 @@ async def calc_services_provision(
 ):
 
     try:
-        token = get_access_token()
+        token = get_mcp_user_id()
         multi_provision_params = MultiProvisionRequestSchema(
             scenario_id=scenario_id,
             services=services,

--- a/docker-compose.actions.yml
+++ b/docker-compose.actions.yml
@@ -7,5 +7,9 @@ services:
       - "9464:9464"
     env_file:
       - .env.development
+    environment:
+      SERVICE_AUTH_SERVER_URL: ${SERVICE_AUTH_SERVER_URL:?SERVICE_AUTH_SERVER_URL is required}
+      SERVICE_AUTH_REALM: ${SERVICE_AUTH_REALM:?SERVICE_AUTH_REALM is required}
+      SERVICE_AUTH_CLIENT_ID: ${SERVICE_AUTH_CLIENT_ID:?SERVICE_AUTH_CLIENT_ID is required}
+      SERVICE_AUTH_CLIENT_SECRET: ${SERVICE_AUTH_CLIENT_SECRET:?SERVICE_AUTH_CLIENT_SECRET is required}
     restart: always
-

--- a/requirements-auth.txt
+++ b/requirements-auth.txt
@@ -1,0 +1,1 @@
+idu-service-auth @ https://github.com/IDUclub/idu-service-auth/archive/1b8a418d9b1ab702860eb7289a3b75244666a8d8.tar.gz

--- a/tests/test_service_auth_transport.py
+++ b/tests/test_service_auth_transport.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+from app.common.api_handler.api_handler import APIHandler
+
+
+class FakeServiceAuth:
+    async def get_authorization_headers(self):
+        return {"Authorization": "Bearer service-token"}
+
+
+@pytest.mark.asyncio
+async def test_service_token_cannot_be_overridden_by_request_headers():
+    handler = APIHandler("http://urban", FakeServiceAuth())
+
+    headers = await handler._service_headers(
+        {"Authorization": "Bearer caller-token", "X-User-Id": "u1"}
+    )
+
+    assert headers["Authorization"] == "Bearer service-token"
+    assert headers["X-User-Id"] == "u1"


### PR DESCRIPTION
## Summary
- create one process-wide idu-service-auth client shared by Urban API handlers
- verify service-account JWTs on HTTP and MCP endpoints
- pass programmatic X-User-Id to Urban API without forwarding user JWTs
- pin idu-service-auth and add mandatory deployment/example environment settings

## Required deployment settings
- Variables: SERVICE_AUTH_SERVER_URL, SERVICE_AUTH_REALM, SERVICE_AUTH_CLIENT_ID
- Secret: SERVICE_AUTH_CLIENT_SECRET

## Verification
- pre-commit passed
- service-auth transport test passed
- Docker build and local HTTP/MCP auth smoke tests passed