### PR TITLE
fix(ci): scope the deploy job to the production environment

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -36,6 +36,9 @@ jobs:
   run_container:
     runs-on: 65_runner
     needs: [build, stop_container]
+    # Required so the SERVICE_AUTH_* vars/secrets of the "production" environment resolve:
+    # without it they come out empty and docker-compose.actions.yml aborts on ${VAR:?...}.
+    environment: production
     env:
       NOW: ${{needs.build.outputs.now}}
     steps:


### PR DESCRIPTION
## Проблема

`run_container` в `build_and_deploy.yml` передаёт в compose четыре переменные service-auth:

```yaml
SERVICE_AUTH_SERVER_URL: ${{ vars.SERVICE_AUTH_SERVER_URL }}
SERVICE_AUTH_REALM: ${{ vars.SERVICE_AUTH_REALM }}
SERVICE_AUTH_CLIENT_ID: ${{ vars.SERVICE_AUTH_CLIENT_ID }}
SERVICE_AUTH_CLIENT_SECRET: ${{ secrets.SERVICE_AUTH_CLIENT_SECRET }}
```

Если они заданы в GitHub Environment `production` (как в gMART, IDU_DVD и NormGraph), в этом job'е они не резолвятся — у job'а нет ключа `environment`, а переменные и секреты окружения видны только внутри job'а, который это окружение объявил. Все четыре приходят пустыми строками, и `docker-compose.actions.yml` падает на `${SERVICE_AUTH_SERVER_URL:?SERVICE_AUTH_SERVER_URL is required}`.

## Изменение

Добавлен `environment: production` в job `run_container` — так же, как это уже сделано в gMART (`build_and_deploy_all.yaml`), IDU_DVD и NormGraph.

Секреты уровня репозитория (`REGISTRY`, `ENV_PATH`), которые используются в job'ах `build` и `run_container`, не затрагиваются — они остаются repository-level и продолжают резолвиться везде.