### PR TITLE
fix: separate MCP user context from service auth

### DIFF
--- a/app/common/api_handler/api_handler.py
+++ b/app/common/api_handler/api_handler.py
@@ -23,6 +23,7 @@ class APIHandler:
         self.service_auth = service_auth
 
     async def _service_headers(self, headers: dict | None) -> dict[str, str]:
+        """Preserve request context while always replacing caller auth with M2M."""
         outgoing = dict(headers or {})
         outgoing.update(await self.service_auth.get_authorization_headers())
         return outgoing

--- a/app/effects/effects_mcp.py
+++ b/app/effects/effects_mcp.py
@@ -56,9 +56,9 @@ async def calc_provision_effects(
 ):
 
     try:
-        token = get_mcp_user_id()
+        user_id = get_mcp_user_id()
         project_id = await effects_mcp_service.gateway.get_project_id_by_scenario(
-            scenario_id, token
+            scenario_id, user_id
         )
         effects_dto = ProvisionDTO(
             project_id=project_id,
@@ -67,7 +67,7 @@ async def calc_provision_effects(
             target_population=target_population,
         )
         result = await effects_mcp_service.calculate_effects(
-            effects_dto, token, for_mcp=True
+            effects_dto, user_id, for_mcp=True
         )
         return result
     except Exception as e:

--- a/app/provision/provision_mcp.py
+++ b/app/provision/provision_mcp.py
@@ -42,9 +42,9 @@ async def calc_service_provision(
 ):
 
     try:
-        token = get_mcp_user_id()
+        user_id = get_mcp_user_id()
         project_id = await provision_mcp_service.gateway.get_project_id_by_scenario(
-            scenario_id, token
+            scenario_id, user_id
         )
         provision_dto = ProvisionDTO(
             project_id=project_id,
@@ -52,7 +52,9 @@ async def calc_service_provision(
             service_type_id=service_type_id,
             target_population=target_population,
         )
-        result = await provision_mcp_service.calculate_provision(provision_dto, token)
+        result = await provision_mcp_service.calculate_provision(
+            provision_dto, user_id
+        )
         return result.model_dump()
     except Exception as e:
         tb = traceback.format_exc()
@@ -115,14 +117,14 @@ async def calc_services_provision(
 ):
 
     try:
-        token = get_mcp_user_id()
+        user_id = get_mcp_user_id()
         multi_provision_params = MultiProvisionRequestSchema(
             scenario_id=scenario_id,
             services=services,
             target_population=target_population,
         )
         result = await provision_mcp_service.calculate_multi_provision(
-            multi_provision_params, token
+            multi_provision_params, user_id
         )
         return result.model_dump()
     except Exception as e:

--- a/tests/test_service_auth_transport.py
+++ b/tests/test_service_auth_transport.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
+from fastmcp.exceptions import ToolError
 
 from app.common.api_handler.api_handler import APIHandler
+from app.common.auth.service_auth import get_mcp_user_id
 
 
 class FakeServiceAuth:
@@ -20,3 +24,23 @@ async def test_service_token_cannot_be_overridden_by_request_headers():
 
     assert headers["Authorization"] == "Bearer service-token"
     assert headers["X-User-Id"] == "u1"
+
+
+def test_mcp_user_context_comes_from_x_user_id_not_authorization():
+    with patch(
+        "app.common.auth.service_auth.get_http_headers",
+        return_value={
+            "authorization": "Bearer service-token",
+            "x-user-id": " user-42 ",
+        },
+    ):
+        assert get_mcp_user_id() == "user-42"
+
+
+def test_mcp_user_context_is_required():
+    with patch(
+        "app.common.auth.service_auth.get_http_headers",
+        return_value={"authorization": "Bearer service-token"},
+    ):
+        with pytest.raises(ToolError, match="X-User-Id header is required"):
+            get_mcp_user_id()


### PR DESCRIPTION
## Что исправлено

- в MCP handlers значение X-User-Id теперь явно называется user_id, а не token;
- зафиксирован контракт транспорта: входной Authorization содержит M2M service token, пользовательский контекст передаётся отдельно через X-User-Id;
- добавлены тесты на обязательность X-User-Id и на невозможность перезаписать исходящий M2M Authorization заголовками вызывающей стороны.

## Проверка

- весь test suite репозитория: 3 passed;
- git diff --check пройден.